### PR TITLE
FilterLifeLevel

### DIFF
--- a/src/InfinitudeThermostat.js
+++ b/src/InfinitudeThermostat.js
@@ -116,6 +116,15 @@ module.exports = class InfinitudeThermostat {
         });
       }.bind(this)
     );
+    
+    thermostatService.getCharacteristic(Characteristic.FilterLifeLevel).on(
+      'get',
+      function(callback) {
+      this.getFilterLifeLevel().then(function(filterlevel) {
+          callback(null, filterlevel);
+        });
+      }.bind(this)
+    );
   }
 
   getTargetTemperatures() {
@@ -149,6 +158,12 @@ module.exports = class InfinitudeThermostat {
   getCurrentRelativeHumidity() {
     return this.getZoneStatus().then(function(status) {
       return parseFloat(status['rh']);
+    });
+  }
+  
+  getFilterLifeLevel() {
+    return this.client.getStatus().then(function(status) {
+      return status.filtrlvl
     });
   }
 


### PR DESCRIPTION
Adding FilterLifeLevel to display 'filtrlvl'. This exposes filter level in HomeKit (and Home App) and creates the possibility of later adding FilterChangeIndication for notifications on filter life.

Note that 'filtrlvl' runs from 0-100 where the integers are % of life used, i.e., 0% means filter is new, 100% means Filter needs to be changed. I believe this is time-based and once it reaches 100% the expected behavior is for a user to change the filter and reset the alert on the thermostat, resetting to 0.

If you have thoughts on adding FilterChangeIndication, please let me know.  I attempted to write this part, but got stuck in some areas of your base-code. A good idea would be to get the FilterLifeLevel and set FilterChangeIndication based on a threshold like >90.